### PR TITLE
Add env for itsdangerous 2.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask==1.1.2
 pandas==1.3.5
+itsdangerous==2.0.1


### PR DESCRIPTION
This patch should fix the `ImportError` cased by the  latest release version of the package `itsdangerous` , when we try to run a Flask application in docker containers, we need to set its version to 2.0.1 , reference to [stackoverflow questions](https://stackoverflow.com/questions/71189819/python-docker-importerror-cannot-import-name-json-from-itsdangerous)
 